### PR TITLE
Fix broken Rocker link

### DIFF
--- a/content/resources/index.md
+++ b/content/resources/index.md
@@ -20,7 +20,7 @@ We will use [Rocker](https://github.com/rocker-org/rocker), a project built on t
 of packages providing analysis tools and datasets we will use throughout the semester. You
 can read more about Rocker in [this introduction](http://dirk.eddelbuettel.com/blog/2014/10/23/)
 
-Instructions on how to setup are found [here]({{< baseurl >}}/homeworks/rocker)
+Instructions on how to setup are found [here]({{< baseurl >}}homeworks/rocker)
 
 ## Other Resources
 

--- a/content/resources/index.md
+++ b/content/resources/index.md
@@ -20,7 +20,7 @@ We will use [Rocker](https://github.com/rocker-org/rocker), a project built on t
 of packages providing analysis tools and datasets we will use throughout the semester. You
 can read more about Rocker in [this introduction](http://dirk.eddelbuettel.com/blog/2014/10/23/)
 
-Instructions on how to setup are found [here]({{< baseurl >}}/homeworks/rocker.html)
+Instructions on how to setup are found [here]({{< baseurl >}}/homeworks/rocker)
 
 ## Other Resources
 


### PR DESCRIPTION
The link to the Rocker setup guide on the resources page is broken. It should direct to either `rocker/index.html` or `rocker`. This PR fixes the link. There's also an extra forward slash in the link, which is removed.

I only edit the markdown, so you'll still have to rebuild the site's HTML.